### PR TITLE
Create rundir_parent when needed

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,13 @@ pub fn build(b: *std.build.Builder) !void {
     const mode = b.standardReleaseOptions();
 
     const socket_path = "/run/rundird.sock";
-    const rundir_parent = "/run/user";
+    const rundir_parent = b.option(
+        []const u8,
+        "rundir-parent",
+        "Absolute path to the parent directory for user dirs. Default is /run/user",
+    ) orelse "/run/user";
+
+    if (!std.fs.path.isAbsolute(rundir_parent)) return error.InvalidRundirParent;
 
     const rundird = b.addExecutable("rundird", "rundird.zig");
     rundird.setTarget(target);

--- a/rundird.zig
+++ b/rundird.zig
@@ -2,6 +2,7 @@
 // XDG_RUNTIME_DIR of the base directory spec.
 //
 // Copyright (C) 2020 Isaac Freund
+// Copyright (C) 2020 Marten Ringwelski
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -53,6 +54,9 @@ pub fn main() !void {
     // This allows us to seteuid() and create rundirs with the correct owner
     // while maintaining write permission to the root owned parent directory.
     _ = try os.prctl(os.PR.SET_SECUREBITS, .{os.SECBIT_NO_SETUID_FIXUP});
+
+    log.info("creating {}\n", .{build_options.rundir_parent});
+    try std.fs.cwd().makePath(build_options.rundir_parent);
 
     var server = std.net.StreamServer.init(.{});
     defer server.deinit();


### PR DESCRIPTION
This is a simple fix for #2.

I didn't make the build options `rundir_parent`and `socket_path` configurable as `socked_path` is unrelated and I am not sure anyone has a usecase for `rundir_parent` to be anything other than `/run/user`.